### PR TITLE
AP_TECS: blend weights when changed

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -1047,10 +1047,11 @@ void AP_TECS::_update_pitch(void)
     _last_pitch_dem = _pitch_dem;
 
     if (AP::logger().should_log(_log_bitmask)){
-        AP::logger().WriteStreaming("TEC2","TimeUS,PEW,EBD,EBE,EBDD,EBDE,EBDDT,Imin,Imax,I,KI,pmin,pmax",
-                                    "Qffffffffffff",
+        AP::logger().WriteStreaming("TEC2","TimeUS,PEW,KEW,EBD,EBE,EBDD,EBDE,EBDDT,Imin,Imax,I,KI,pmin,pmax",
+                                    "Qfffffffffffff",
                                     AP_HAL::micros64(),
                                     (double)SPE_weighting,
+                                    (double)_SKE_weighting,
                                     (double)SEB_dem,
                                     (double)SEB_est,
                                     (double)SEBdot_dem,

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -183,6 +183,7 @@ private:
     AP_Float _vertAccLim;
     AP_Float _rollComp;
     AP_Float _spdWeight;
+    AP_Float _spdWeightBlendFactor;
     AP_Float _spdWeightLand;
     AP_Float _landThrottle;
     AP_Float _landAirspeed;
@@ -415,6 +416,7 @@ private:
     bool _need_reset;
 
     float _SKE_weighting;
+    float _SKE_weighting_prev;
 
     AP_Int8 _use_synthetic_airspeed;
     


### PR DESCRIPTION
## Context
Weights change in a step manner which can cause large pitch commands specifically for quadplanes after transition.

## Proposal
Blend the speed weighting.

## Testing:  note this testing has the logging added for TECS SKE (https://github.com/ArduPilot/ardupilot/pull/25287)
### Initial testing
[before_with_poor_handoff.BIN.txt](https://github.com/magate/ardupilot/files/12936188/before_with_poor_handoff.BIN.txt)

![image](https://github.com/magate/ardupilot/assets/69254089/bdaf7a9a-ae12-4b47-9539-bd4b36bf2d02)
Figure: TECS weights with airspeed. 1) start of transition 2) end of transition

![image](https://github.com/magate/ardupilot/assets/69254089/d389c3f5-61cd-4da2-bafb-9aa3940bc760)
Figure: TECS weights with DesPitch. 1) Start of transition, `TEC2.KEW` steps and pitch steps in unison. 2) End of transition, `TEC2.KEW` steps and DesPitch steps in unison.

### After change testing with blend factor 1 to test no effect
[after_with_default_1.BIN.txt](https://github.com/magate/ardupilot/files/12936505/after_with_default_1.BIN.txt)

![image](https://github.com/magate/ardupilot/assets/69254089/4c8afedd-29d4-4509-b8e1-dc605643cfc8)
Figure: TECS weights with airspeed. 1) start of transition 2) end of transition

![image](https://github.com/magate/ardupilot/assets/69254089/98a43988-557e-47c1-b492-87e64a90c0e0)
Figure: TECS weights with DesPitch. 1) Start of transition, `TEC2.KEW` steps and pitch steps in unison. 2) End of transition, `TEC2.KEW` steps and DesPitch steps in unison. Default behavior remains the same.

### After change with blend factor 100
[after_with_blend_100.BIN.txt](https://github.com/magate/ardupilot/files/12936507/after_with_blend_100.BIN.txt)

![image](https://github.com/magate/ardupilot/assets/69254089/96c1728b-f882-48a3-841f-3e633dbcbb9c)
Figure: Figure: TECS weights with airspeed. 1) start of transition 2) ~end of transition

![image](https://github.com/magate/ardupilot/assets/69254089/893ea936-27c9-4e77-bf28-995ef51f822e)
Figure: TECS weights with DesPitch. 1) Start of transition, `TEC2.KEW` ramps and pitch steps to a lesser extend (-2.5 instead of -5). 2) End of transition, `TEC2.KEW` ramps and DesPitch remains smooth.

## CAUTION
This change does result in significant altitude loss when performing detransition with a blend factor of 100. A smaller blend factor should likely be used.
![image](https://github.com/magate/ardupilot/assets/69254089/d370e426-3551-4874-8409-ae17761107e2)

For example, a blend factor of 10 results in -3.5 des pitch in transition (instead of -5.5) and ~ 1 meter of altitude lost in detranstion.
