### PR TITLE
Plane: fix Q_OPTION bit 18 docstring

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -283,7 +283,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @Bitmask: 15: ThrLandControl-enable throttle stick control of landing rate
     // @Bitmask: 16: DisableApproach-disable use of approach and airbrake stages in VTOL landing
     // @Bitmask: 17: EnableLandResposition-enable pilot controlled repositioning in AUTO land.Descent will pause while repositioning
-    // @Bitmask: 18: ARMVTOL-arm only in VTOL or AUTO modes
+    // @Bitmask: 18: ARMVTOL-arm only in VTOL or AUTO modes when current nav cmd is VTOL Takeoff
     // @Bitmask: 19: CompleteTransition-to fixed wing if Q_TRANS_FAIL timer times out instead of QLAND
     // @Bitmask: 20: Force RTL mode-forces RTL mode on rc failsafe in VTOL modes overriding bit 5(USE_QRTL)
     // @Bitmask: 21: Tilt rotor-tilt motors up when disarmed in FW modes (except manual) to prevent ground strikes.


### PR DESCRIPTION
This docstring is not correct.

https://github.com/ArduPilot/ardupilot/blob/8e9a568a55be2d4129e0b06f460c82bd7dec7953/ArduPlane/mode_auto.cpp#L152-L162